### PR TITLE
Pass empty onSongInfo to panel.hw.connect() to skip shared-DOM writes

### DIFF
--- a/screen.js
+++ b/screen.js
@@ -234,8 +234,11 @@
             panel.tabBtn.style.opacity = '0.4';
         }
 
-        // Connect WebSocket
-        panel.hw.connect(getWsUrl(currentFilename, arrIndex));
+        // Connect WebSocket. Pass an empty onSongInfo so core skips its
+        // default writes to shared HUD / audio / arrangement dropdown
+        // — otherwise every panel's song_info clobbers the main view.
+        // See byrongamatos/slopsmith#27.
+        panel.hw.connect(getWsUrl(currentFilename, arrIndex), { onSongInfo: () => {} });
     }
 
     async function togglePanelTab(panel) {


### PR DESCRIPTION
## Summary
Adopts the `opts` parameter added in [byrongamatos/slopsmith#27](https://github.com/byrongamatos/slopsmith/pull/27) so that splitscreen panels stop stomping on the main view's shared DOM when they receive `song_info` messages.

## What was happening
Every panel's `connect()` runs core's default `song_info` handler, which writes to:
- `#hud-artist`, `#hud-title`, `#hud-arrangement`
- The shared `<audio>` element (`src`, `load()`, `progress`/`canplaythrough` listeners)
- `#audio-buffer-overlay` created in `document.body`
- `#arr-select` arrangement dropdown

In splitscreen these writes overlap: HUD and dropdown reflect whichever panel's `song_info` arrived last; the audio element gets extra `src=` / `load()` attempts (gated by an `includes()` check in core, but still); audio listeners rebind per panel.

## Change
One line at `screen.js:238`:
```diff
-        panel.hw.connect(getWsUrl(currentFilename, arrIndex));
+        panel.hw.connect(getWsUrl(currentFilename, arrIndex), { onSongInfo: () => {} });
```
Empty callback means "don't do the default writes, I have nothing to add." The panel's own arrangement label is already rendered via `panel.arrName.textContent = arrangements[arrIndex]?.name`.

## Dependency / deployment
- **Depends on byrongamatos/slopsmith#27 merging and being deployed.** On older slopsmith versions the second arg to `connect()` is silently ignored, so this change is a no-op until core catches up.
- No other plugin change needed. `reconnect()` (triggered when switching a panel's arrangement) already reuses the stored opts in core #27, so the skip persists across arrangement changes.

## Verification (after slopsmith#27 lands)
- Enter 2-panel splitscreen → HUD still shows the main arrangement (not a panel's).
- Switch one panel's arrangement via its dropdown → main HUD unchanged, per-panel `arrName` updates, main dropdown unchanged.
- DevTools: one `audio.src` write per song load, not N.

Related: byrongamatos/slopsmith#24 (stop() audio leak), #26 (lyrics persistence) — combined with this, splitscreen's "leaving split screen breaks play" and "lyrics always on" issues are closed out.
