### PR TITLE
Fix player controls jumping to top in split mode

### DIFF
--- a/screen.js
+++ b/screen.js
@@ -371,11 +371,14 @@
             initPanel(panel, arrDefaults[i]);
         }
 
-        // Hide default highway canvas, ensure controls stay on top
+        // Hide default highway canvas, ensure controls stay on top and at bottom
         const defaultCanvas = document.getElementById('highway');
         if (defaultCanvas) defaultCanvas.style.display = 'none';
         const controls = document.getElementById('player-controls');
-        if (controls) controls.style.zIndex = '10';
+        if (controls) {
+            controls.style.zIndex = '10';
+            controls.style.marginTop = 'auto';
+        }
 
         sizeCanvases();
         active = true;
@@ -393,7 +396,10 @@
         const defaultCanvas = document.getElementById('highway');
         if (defaultCanvas) defaultCanvas.style.display = '';
         const controls = document.getElementById('player-controls');
-        if (controls) controls.style.zIndex = '';
+        if (controls) {
+            controls.style.zIndex = '';
+            controls.style.marginTop = '';
+        }
 
         updateBtn();
         stopTimeSync();


### PR DESCRIPTION
## Summary
- Hiding `#highway` (`display:none`) removes the `flex:1` child from the `#player` flex column, causing `#player-controls` to float to the top of the screen
- Adds `margin-top: auto` to controls while split screen is active to keep them pinned at the bottom
- Cleans up the style on exit so normal layout is restored

## Test plan
- [x] Play a song, enter split screen — controls should stay at the bottom
- [x] Exit split screen — controls should remain at the bottom (no layout change)
- [x] Try all three layouts (top/bottom, left/right, quad) — controls stay at bottom in each

🤖 Generated with [Claude Code](https://claude.com/claude-code)