### PR TITLE
Persist panel prefs and add auto-reactivate setting

### DIFF
--- a/screen.js
+++ b/screen.js
@@ -21,6 +21,7 @@
     let active = false;
     let layout = localStorage.getItem('splitscreenLayout') || 'top-bottom';
     let autoReactivate = localStorage.getItem('splitscreenAutoReactivate') === 'true';
+    let alwaysSplit = localStorage.getItem('splitscreenAlwaysSplit') === 'true';
     let panels = [];       // { hw, canvas, ws, arrIndex, controls }
     let wrap = null;
     let currentFilename = null;
@@ -43,6 +44,15 @@
         autoReactivateCheckbox.addEventListener('change', () => {
             autoReactivate = autoReactivateCheckbox.checked;
             localStorage.setItem('splitscreenAutoReactivate', autoReactivate);
+        });
+    }
+
+    const alwaysSplitCheckbox = document.getElementById('splitscreen-always-split');
+    if (alwaysSplitCheckbox) {
+        alwaysSplitCheckbox.checked = alwaysSplit;
+        alwaysSplitCheckbox.addEventListener('change', () => {
+            alwaysSplit = alwaysSplitCheckbox.checked;
+            localStorage.setItem('splitscreenAlwaysSplit', alwaysSplit);
         });
     }
 
@@ -588,8 +598,7 @@
             if (origOnReady) origOnReady();
             highway._onReady = null;
 
-            // Auto-reactivate split screen with saved prefs
-            if (wasActive && autoReactivate) {
+            if (alwaysSplit || (wasActive && autoReactivate)) {
                 startSplitScreen();
             }
         };

--- a/screen.js
+++ b/screen.js
@@ -16,9 +16,11 @@
 
     const OFF_CLASS = 'px-3 py-1.5 bg-dark-600 hover:bg-dark-500 rounded-lg text-xs text-gray-300 transition';
     const ON_CLASS  = 'px-3 py-1.5 bg-blue-900/50 hover:bg-blue-900/60 rounded-lg text-xs text-blue-300 transition';
+    const STORAGE_KEY = 'splitscreenPanelPrefs';
 
     let active = false;
     let layout = localStorage.getItem('splitscreenLayout') || 'top-bottom';
+    let autoReactivate = localStorage.getItem('splitscreenAutoReactivate') === 'true';
     let panels = [];       // { hw, canvas, ws, arrIndex, controls }
     let wrap = null;
     let currentFilename = null;
@@ -33,6 +35,42 @@
             localStorage.setItem('splitscreenLayout', layout);
             if (active) rebuildLayout();
         });
+    }
+
+    const autoReactivateCheckbox = document.getElementById('splitscreen-auto-reactivate');
+    if (autoReactivateCheckbox) {
+        autoReactivateCheckbox.checked = autoReactivate;
+        autoReactivateCheckbox.addEventListener('change', () => {
+            autoReactivate = autoReactivateCheckbox.checked;
+            localStorage.setItem('splitscreenAutoReactivate', autoReactivate);
+        });
+    }
+
+    // ── Panel preference persistence ──
+    function savePanelPrefs() {
+        const prefs = panels.map(p => ({
+            arrName: arrangements[p.arrIndex]?.name || '',
+            lyrics: typeof p.hw.getLyricsVisible === 'function' ? p.hw.getLyricsVisible() : true,
+            inverted: p.hw.getInverted(),
+        }));
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+    }
+
+    function loadPanelPrefs() {
+        try {
+            return JSON.parse(localStorage.getItem(STORAGE_KEY)) || null;
+        } catch (_) {
+            return null;
+        }
+    }
+
+    function resolveArrIndex(arrName) {
+        if (!arrName) return -1;
+        const lower = arrName.toLowerCase();
+        for (let i = 0; i < arrangements.length; i++) {
+            if ((arrangements[i].name || '').toLowerCase() === lower) return i;
+        }
+        return -1;
     }
 
     // ── Helpers ──
@@ -180,9 +218,17 @@
     }
 
     // ── Panel lifecycle ──
-    function initPanel(panel, arrIndex) {
+    function initPanel(panel, arrIndex, prefs) {
         panel.arrIndex = arrIndex;
         panel.hw.init(panel.canvas);
+
+        // Apply saved preferences
+        if (prefs) {
+            if (prefs.inverted !== undefined) panel.hw.setInverted(prefs.inverted);
+            if (prefs.lyrics !== undefined && typeof panel.hw.setLyricsVisible === 'function') {
+                panel.hw.setLyricsVisible(prefs.lyrics);
+            }
+        }
 
         // Populate arrangement dropdown
         panel.select.innerHTML = '';
@@ -199,6 +245,7 @@
         panel.select.onchange = () => {
             const newIdx = parseInt(panel.select.value);
             switchPanelArrangement(panel, newIdx);
+            savePanelPrefs();
         };
 
         // Per-panel invert toggle
@@ -207,6 +254,7 @@
             const on = !panel.hw.getInverted();
             panel.hw.setInverted(on);
             panel.updateInvertStyle(on);
+            savePanelPrefs();
         };
 
         // Per-panel lyrics toggle (uses highway factory's per-instance showLyrics)
@@ -217,6 +265,7 @@
                 const on = !panel.hw.getLyricsVisible();
                 panel.hw.setLyricsVisible(on);
                 panel.updateLyricsStyle(on);
+                savePanelPrefs();
             };
         } else {
             panel.lyricsBtn.disabled = true;
@@ -325,26 +374,49 @@
     // ── Main toggle ──
     function rebuildLayout() {
         const wasActive = active;
-        const oldArrangements = panels.map(p => p.arrIndex);
+        const savedPrefs = wasActive ? captureCurrentPrefs() : null;
         teardownPanels();
-        if (wasActive) startSplitScreen(oldArrangements);
+        if (wasActive) startSplitScreen(null, savedPrefs);
     }
 
-    function startSplitScreen(existingArrangements) {
+    function captureCurrentPrefs() {
+        return panels.map(p => ({
+            arrName: arrangements[p.arrIndex]?.name || '',
+            lyrics: typeof p.hw.getLyricsVisible === 'function' ? p.hw.getLyricsVisible() : true,
+            inverted: p.hw.getInverted(),
+        }));
+    }
+
+    function startSplitScreen(existingArrangements, savedPrefs) {
         const info = highway.getSongInfo();
         if (info && info.arrangements) {
             arrangements = info.arrangements;
         }
         if (arrangements.length === 0) return;
 
+        // If no explicit arrangements or prefs passed, try loading from storage
+        if (!existingArrangements && !savedPrefs) {
+            savedPrefs = loadPanelPrefs();
+        }
+
         const cfg = LAYOUTS[layout];
         const container = createWrap();
         applyLayoutStyle(container, layout);
 
         // Determine arrangements for each panel
-        const arrDefaults = existingArrangements && existingArrangements.length >= cfg.panels
-            ? existingArrangements.slice(0, cfg.panels)
-            : getDefaultArrangements(cfg.panels);
+        let arrDefaults;
+        if (existingArrangements && existingArrangements.length >= cfg.panels) {
+            arrDefaults = existingArrangements.slice(0, cfg.panels);
+        } else if (savedPrefs && savedPrefs.length > 0) {
+            arrDefaults = [];
+            for (let i = 0; i < cfg.panels; i++) {
+                const pref = savedPrefs[i % savedPrefs.length];
+                const idx = pref ? resolveArrIndex(pref.arrName) : -1;
+                arrDefaults.push(idx >= 0 ? idx : getDefaultArrangements(1)[0]);
+            }
+        } else {
+            arrDefaults = getDefaultArrangements(cfg.panels);
+        }
 
         for (let i = 0; i < cfg.panels; i++) {
             const parts = createPanel(i, container, layout);
@@ -368,7 +440,8 @@
             };
 
             panels.push(panel);
-            initPanel(panel, arrDefaults[i]);
+            const panelPrefs = savedPrefs ? savedPrefs[i % savedPrefs.length] : null;
+            initPanel(panel, arrDefaults[i], panelPrefs);
         }
 
         // Hide default highway canvas, ensure controls stay on top and at bottom
@@ -383,12 +456,14 @@
         sizeCanvases();
         active = true;
         updateBtn();
+        savePanelPrefs();
 
         // Hook into the time sync loop
         startTimeSync();
     }
 
     function stopSplitScreen() {
+        savePanelPrefs();
         teardownPanels();
         active = false;
 
@@ -498,7 +573,7 @@
     // ── Hook into playSong ──
     const _play = window.playSong;
     window.playSong = async function (f, a) {
-        // Teardown any active split screen before playing new song
+        const wasActive = active;
         if (active) stopSplitScreen();
         await _play(f, a);
 
@@ -512,6 +587,11 @@
             }
             if (origOnReady) origOnReady();
             highway._onReady = null;
+
+            // Auto-reactivate split screen with saved prefs
+            if (wasActive && autoReactivate) {
+                startSplitScreen();
+            }
         };
 
         injectBtn();

--- a/settings.html
+++ b/settings.html
@@ -8,4 +8,11 @@
             <option value="quad">Quad (4P)</option>
         </select>
     </div>
+    <div class="flex items-center gap-3 mt-3">
+        <label class="text-sm text-gray-300 cursor-pointer flex items-center gap-2">
+            <input type="checkbox" id="splitscreen-auto-reactivate" class="accent-blue-500 w-4 h-4">
+            Remember split screen between songs
+        </label>
+        <span class="text-xs text-gray-500">Auto-reactivate with your panel preferences when loading a new song</span>
+    </div>
 </div>

--- a/settings.html
+++ b/settings.html
@@ -10,9 +10,16 @@
     </div>
     <div class="flex items-center gap-3 mt-3">
         <label class="text-sm text-gray-300 cursor-pointer flex items-center gap-2">
+            <input type="checkbox" id="splitscreen-always-split" class="accent-blue-500 w-4 h-4">
+            Always enter split screen
+        </label>
+        <span class="text-xs text-gray-500">Automatically split every song on play</span>
+    </div>
+    <div class="flex items-center gap-3 mt-3">
+        <label class="text-sm text-gray-300 cursor-pointer flex items-center gap-2">
             <input type="checkbox" id="splitscreen-auto-reactivate" class="accent-blue-500 w-4 h-4">
             Remember split screen between songs
         </label>
-        <span class="text-xs text-gray-500">Auto-reactivate with your panel preferences when loading a new song</span>
+        <span class="text-xs text-gray-500">Re-enter split with your panel preferences when switching songs</span>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- Per-panel preferences (arrangement choice, lyrics on/off, invert on/off) are saved to `localStorage` and restored when re-entering split screen
- Arrangements are matched by name (e.g. "Lead", "Bass") so prefs carry across different songs with the same arrangement types
- New setting: **"Remember split screen between songs"** — when enabled, split screen auto-reactivates with your saved panel config on song change. Off by default.
- Prefs are saved on every toggle/change (arrangement select, lyrics, invert) and on split screen enter/exit

## Test plan
- [x] Enter split screen, assign Lead/Bass to panels, toggle lyrics off on one panel
- [x] Exit and re-enter split screen — prefs should be restored
- [x] Play a different song, click Split — arrangement names should match (Lead stays Lead)
- [x] Enable "Remember split screen between songs" in settings
- [x] Play a new song — split screen should auto-activate with saved prefs
- [x] Disable the setting — split screen should NOT auto-activate on song change
- [x] Switch layout (top/bottom → quad) — prefs should carry over to the new panel count

🤖 Generated with [Claude Code](https://claude.com/claude-code)