### PR TITLE
Fix bottom panels overlapping global controls in quad mode

### DIFF
--- a/screen.js
+++ b/screen.js
@@ -290,8 +290,9 @@
     }
 
     function applyLayoutStyle(container, layoutKey) {
+        // Note: bottom is set dynamically by sizeCanvases() to leave room for global controls
         container.style.cssText =
-            'position:absolute;top:0;left:0;right:0;bottom:0;z-index:3;display:flex;';
+            'position:absolute;top:0;left:0;right:0;z-index:3;display:flex;';
         if (layoutKey === 'top-bottom') {
             container.style.flexDirection = 'column';
         } else if (layoutKey === 'left-right') {


### PR DESCRIPTION
## Summary
- Remove `bottom:0` from `applyLayoutStyle` cssText to fix quad mode layout issue
- The wrap container's bottom is now set only by `sizeCanvases()`, which correctly calculates the offset needed for global player controls

## Problem
In quad split screen mode, the bottom two panels' individual control bars were rendering underneath the global toolbar at the bottom of the screen.

## Fix
The initial `bottom:0` in the cssText was being set before `sizeCanvases()` could override it with the proper value. By removing `bottom:0` from the initial styles, the container doesn't briefly extend to the very bottom, and `sizeCanvases()` properly sets the offset from the start.

## Test plan
- [x] Open a song in the player
- [x] Enable split screen in quad mode
- [x] Verify the bottom two panels' control bars are visible above the global controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)