### PR TITLE
Fix global controls z-index by adding position:relative

### DIFF
--- a/screen.js
+++ b/screen.js
@@ -708,6 +708,7 @@
         if (defaultCanvas) defaultCanvas.style.display = 'none';
         const controls = document.getElementById('player-controls');
         if (controls) {
+            controls.style.position = 'relative';  // Required for z-index to work
             controls.style.zIndex = '10';
             controls.style.marginTop = 'auto';
         }


### PR DESCRIPTION
## Summary
- Add `position: relative` to player-controls element so that `z-index: 10` actually takes effect

## Problem
The previous fix removed `bottom:0` from the wrap container, but the global controls were still being overlapped by the bottom panels' mini control bars in quad mode. This was because `z-index` only applies to positioned elements, and `#player-controls` had no positioning set.

## Fix
Adding `position: relative` to the controls element makes it a positioned element, allowing the `z-index: 10` to properly stack it above the splitscreen wrap (z-index: 3).

## Test plan
- [x] Open a song in the player
- [x] Enable split screen in quad mode  
- [x] Verify the global controls bar is fully visible and clickable above the bottom panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)