### PR TITLE
feat: hide redundant main-bar controls while split is active

### DIFF
--- a/screen.js
+++ b/screen.js
@@ -1128,6 +1128,7 @@
         sizeCanvases();
         active = true;
         updateBtn();
+        setRedundantControlsHidden(true);
         savePanelPrefs();
 
         if (localStorage.getItem('splitscreenControlsHidden') === 'true') toggleControlsVisibility();
@@ -1140,6 +1141,7 @@
         savePanelPrefs();
         teardownPanels();
         active = false;
+        setRedundantControlsHidden(false);
 
         // Restore default highway canvas and controls z-index
         const defaultCanvas = document.getElementById('highway');
@@ -1218,6 +1220,25 @@
         };
         if (separator) c.insertBefore(layoutBtn, separator);
         return layoutBtn;
+    }
+
+    // ── Redundant main-bar controls (hidden while split is active because each
+    // panel exposes its own arrangement / mastery / lyrics / viz controls) ──
+    const REDUNDANT_CONTROL_IDS = [
+        'arr-select',
+        'mastery-slider-label',
+        'mastery-slider',
+        'mastery-label',
+        'btn-lyrics',
+        'viz-picker-label',
+        'viz-picker',
+    ];
+
+    function setRedundantControlsHidden(hide) {
+        for (const id of REDUNDANT_CONTROL_IDS) {
+            const el = document.getElementById(id);
+            if (el) el.style.display = hide ? 'none' : '';
+        }
     }
 
     // ── Hide/show controls bar ──


### PR DESCRIPTION
## Summary

When split screen is active, each panel already exposes its own arrangement selector, mastery slider, lyrics overlay toggle, and viz picker. The matching controls on the main `#player-controls` bar become redundant and just clutter the bar. They are hidden on `startSplitScreen` and restored on `stopSplitScreen`.

Hidden while split is active:
- `#arr-select`
- `#mastery-slider-label` / `#mastery-slider` / `#mastery-label`
- `#btn-lyrics`
- `#viz-picker-label` / `#viz-picker`

Global controls retained: play/pause, seek, speed, volume, quality, loop A/B/save/clear, close.

## Test plan

- [ ] Activate split — those four control groups disappear from the main bar
- [ ] Deactivate split — they all return
- [ ] Toggle split repeatedly — no leftover hidden state
- [ ] Confirm per-panel equivalents still work (arrangement dropdown, mastery slider, lyrics toggle)
- [ ] Confirm global controls (play, speed, volume, loop, close) are still functional during split

🤖 Generated with [Claude Code](https://claude.com/claude-code)