### PR TITLE
chore: bump plugin version to 1.1.0

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "splitscreen",
   "name": "Split Screen",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": false,
   "settings": { "html": "settings.html" },
   "script": "screen.js"


### PR DESCRIPTION
## Summary

Bump `plugin.json` from `1.0.0` → `1.1.0` to reflect the additive features and fixes merged since 1.0.0:

- Hide/show global + per-panel control bars
- Per-panel master difficulty slider
- Per-panel 3D Highway palette picker
- Lyrics overlay toggle always visible
- Redundant main-bar controls hidden while split active
- Song HUD fade on playback start
- `window.slopsmithSplitscreen.panelIndexFor(canvas)` public API
- Section Map plugin no longer overlaps top panels
- Charts no longer mix on mid-song arrangement switch (#22)
- Controls bar stays above 3D Highway canvas at all times

All changes are additive — minor bump under semver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)