### PR TITLE
feat: per-panel camera smoothing slider for 3D Highway panels

### DIFF
--- a/screen.js
+++ b/screen.js
@@ -439,6 +439,31 @@
         }
         bar.appendChild(paletteSelect);
 
+        // Per-panel camera-smoothing slider (3D-only). Mirrors the plugin's
+        // global slider in settings.html but writes the per-panel localStorage
+        // key so this panel can have its own feel without touching the global.
+        const camSmoothingWrap = document.createElement('span');
+        camSmoothingWrap.title = '3D camera smoothing (this panel only)';
+        camSmoothingWrap.style.cssText =
+            'display:none;align-items:center;gap:4px;white-space:nowrap;';
+        const camSmoothingHeading = document.createElement('span');
+        camSmoothingHeading.style.cssText = 'font-size:10px;color:#6b7280;';
+        camSmoothingHeading.textContent = 'Cam';
+        const camSmoothingSlider = document.createElement('input');
+        camSmoothingSlider.type = 'range';
+        camSmoothingSlider.min = '0';
+        camSmoothingSlider.max = '1';
+        camSmoothingSlider.step = '0.05';
+        camSmoothingSlider.value = '0.5';
+        camSmoothingSlider.style.cssText = 'width:70px;';
+        const camSmoothingLabel = document.createElement('span');
+        camSmoothingLabel.style.cssText = 'font-size:10px;color:#9ca3af;width:24px;text-align:right;';
+        camSmoothingLabel.textContent = '0.50';
+        camSmoothingWrap.appendChild(camSmoothingHeading);
+        camSmoothingWrap.appendChild(camSmoothingSlider);
+        camSmoothingWrap.appendChild(camSmoothingLabel);
+        bar.appendChild(camSmoothingWrap);
+
         const masteryHeading = document.createElement('span');
         masteryHeading.style.cssText = 'font-size:10px;color:#6b7280;white-space:nowrap;';
         masteryHeading.textContent = 'Mastery';
@@ -483,6 +508,7 @@
             detectBtn, updateDetectStyle,
             channelBtn, viewBtn,
             paletteSelect,
+            camSmoothingWrap, camSmoothingSlider, camSmoothingLabel,
             masteryHeading, masterySlider, masteryLabel,
         };
     }
@@ -557,6 +583,31 @@
             return 'default';
         }
     }
+    function _readPanelCameraSmoothing(panelIdx) {
+        try {
+            const stored = localStorage.getItem('h3d_bg_panel' + panelIdx + '_cameraSmoothing')
+                ?? localStorage.getItem('h3d_bg_cameraSmoothing');
+            const n = stored == null ? 0.5 : parseFloat(stored);
+            return Number.isFinite(n) ? Math.max(0, Math.min(1, n)) : 0.5;
+        } catch (_) {
+            return 0.5;
+        }
+    }
+    function _writePanelCameraSmoothing(panelIdx, value) {
+        const v = String(value);
+        try { localStorage.setItem('h3d_bg_panel' + panelIdx + '_cameraSmoothing', v); } catch (_) {}
+        // Re-fire the global setter with its existing value so the 3D
+        // plugin's _bgEmitChange runs and each renderer re-reads its
+        // settings — picking up the per-panel override we just wrote.
+        // No global state changes hands.
+        if (typeof window.h3dBgSetCameraSmoothing === 'function') {
+            const cur = (() => {
+                try { return localStorage.getItem('h3d_bg_cameraSmoothing') || '0.5'; }
+                catch (_) { return '0.5'; }
+            })();
+            window.h3dBgSetCameraSmoothing(cur);
+        }
+    }
     function _writePanelPalette(panelIdx, value) {
         try { localStorage.setItem('h3d_bg_panel' + panelIdx + '_palette', value); } catch (_) {}
         if (typeof window.h3dBgSetPalette === 'function') {
@@ -576,6 +627,19 @@
     }
     function hidePaletteSelect(panel) {
         panel.paletteSelect.style.display = 'none';
+    }
+
+    function showCamSmoothing(panel) {
+        const idx = panels.indexOf(panel);
+        if (idx === -1) return;
+        if (typeof window.slopsmithViz_highway_3d !== 'function') return;
+        const v = _readPanelCameraSmoothing(idx);
+        panel.camSmoothingSlider.value = String(v);
+        panel.camSmoothingLabel.textContent = v.toFixed(2);
+        panel.camSmoothingWrap.style.display = '';
+    }
+    function hideCamSmoothing(panel) {
+        panel.camSmoothingWrap.style.display = 'none';
     }
 
     // ── Mastery slider helpers ──
@@ -647,6 +711,7 @@
         panel.masterySlider.style.display = 'none';
         panel.masteryLabel.style.display = 'none';
         hidePaletteSelect(panel);
+        hideCamSmoothing(panel);
 
         panel.lyricsPane = createLyricsPane(panel.panelDiv);
         panel.lyricsPane.el.style.bottom = (panel.bar.offsetHeight || 28) + 'px';
@@ -697,6 +762,7 @@
         panel.masterySlider.style.display = 'none';
         panel.masteryLabel.style.display = 'none';
         hidePaletteSelect(panel);
+        hideCamSmoothing(panel);
 
         const jtContainer = document.createElement('div');
         jtContainer.style.cssText =
@@ -765,6 +831,7 @@
         panel.hw.connect(getWsUrl(currentFilename, panel.arrIndex), { onSongInfo: () => {} });
         panel.hw3dMode = true;
         showPaletteSelect(panel);
+        showCamSmoothing(panel);
 
         panel.updateInvertStyle(panel.hw.getInverted());
         panel.invertBtn.onclick = () => {
@@ -787,6 +854,7 @@
         panel.hw.setRenderer(null);
         panel.hw3dMode = false;
         hidePaletteSelect(panel);
+        hideCamSmoothing(panel);
 
         panel.tabBtn.style.display = '';
 
@@ -852,6 +920,14 @@
             const idx = panels.indexOf(panel);
             if (idx === -1) return;
             _writePanelPalette(idx, panel.paletteSelect.value);
+        };
+
+        panel.camSmoothingSlider.oninput = () => {
+            const idx = panels.indexOf(panel);
+            if (idx === -1) return;
+            const v = parseFloat(panel.camSmoothingSlider.value);
+            panel.camSmoothingLabel.textContent = (Number.isFinite(v) ? v : 0.5).toFixed(2);
+            _writePanelCameraSmoothing(idx, v);
         };
 
         // Populate arrangement dropdown (includes Lyrics, JT, and 3D options)


### PR DESCRIPTION
## Summary

Adds a small **Cam** slider to each splitscreen panel's mini control bar, shown only when the panel is in 3D Highway mode. Lets each 3D panel run with its own camera-smoothing setting independent of the global value.

The 3D Highway plugin already reads `h3d_bg_panel<N>_cameraSmoothing` ahead of the global `h3d_bg_cameraSmoothing` (per-panel infrastructure was wired up at the same time as per-panel palettes). The read path was already done — this PR only adds the write path and the UI to use it.

## Implementation

Mirrors the existing per-panel palette picker exactly:

- **`_readPanelCameraSmoothing(panelIdx)`** / **`_writePanelCameraSmoothing(panelIdx, value)`** — same idiom as `_readPanelPalette` / `_writePanelPalette`. Writes the per-panel localStorage key, then re-fires the global setter (with its existing value) so the 3D plugin's `_bgEmitChange` broadcasts and each renderer re-reads its settings, picking up the per-panel override.
- **Slider element** — 70 px wide range input + numeric readout, plugged into the panel bar next to the palette picker, with the same hidden-by-default styling.
- **`showCamSmoothing(panel)` / `hideCamSmoothing(panel)`** — toggles visibility, hydrates from `_readPanelCameraSmoothing` when shown. Called alongside `showPaletteSelect` / `hidePaletteSelect` at the same four mode-transition sites (`enter3DHwMode` shows; `exit3DHwMode`, `enterLyricsMode`, `enterJumpingTabMode` hide).

## What this builds on

- 3D Highway PR upstream `byrongamatos#40` (extends the global `cameraSmoothing` to also damp zoom + widens the X dead zone). The per-panel slider just exposes the same already-extended dial on a per-panel basis.

## Test plan
- [ ] Splitscreen with two 3D panels → each panel shows its own Cam slider on the mini bar
- [ ] Move panel 0's slider to **Calm** while leaving panel 1's at **Twitchy** → only panel 0's camera dampens; panel 1 behaves normally
- [ ] Setting persists per panel across reload (each panel restores its saved smoothing on the next session)
- [ ] Switching a panel out of 3D mode (to Lyrics / Jumping Tab / a 2D arrangement) hides the Cam slider
- [ ] Switching back into 3D mode re-shows the slider hydrated from the saved per-panel value
- [ ] Global slider in plugin settings.html still works as a fallback for panels that don't have a per-panel value set

🤖 Generated with [Claude Code](https://claude.com/claude-code)