### PR TITLE
fix: per-panel control bar disappearing in popup windows (1.3.1)

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "splitscreen",
   "name": "Split Screen",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": false,
   "settings": { "html": "settings.html" },
   "script": "screen.js"

--- a/screen.js
+++ b/screen.js
@@ -1870,8 +1870,15 @@
     }
 
     // ── Resize handler ──
+    // sizeCanvases() is for main-window splitscreen — it reads the global
+    // #player-controls height to compute the wrap's bottom offset. In a
+    // popup #player-controls is force-hidden, so offsetHeight is 0 and
+    // sizeCanvases would clobber the follower wrap's `bottom: FOLLOWER_TOOLBAR_H`
+    // reservation, sliding the wrap (and every panel's bar) under the
+    // follower toolbar. Follower mode has its own resize handler in
+    // bootFollowerMode that resizes panels without touching the wrap.
     window.addEventListener('resize', () => {
-        if (active) sizeCanvases();
+        if (active && !FOLLOWER) sizeCanvases();
     });
 
     // ── Hook into playSong ──
@@ -2017,10 +2024,17 @@
             } catch (_) {}
         });
 
-        // Resize handler: panels[0] is always the live follower panel after
-        // any song-change rebuild, so this single listener stays correct.
+        // Resize handler: walk every live panel — multi-panel popups
+        // (top-bottom, left-right, quad) need each highway / JT pane
+        // resized, not just panels[0]. Mirrors sizeCanvases()'s loop
+        // shape but doesn't touch wrap positioning (the follower wrap's
+        // top/bottom are set once at build time and don't need to track
+        // window chrome the way the main-window wrap does).
         window.addEventListener('resize', () => {
-            if (panels[0]) panels[0].hw.resize();
+            for (const p of panels) {
+                if (p.jumpingTabMode && p.jumpingTabPane) p.jumpingTabPane.resize();
+                else if (!p.lyricsMode) p.hw.resize();
+            }
         });
 
         // Wait one frame so all plugin IIFEs that loaded before us have
@@ -2146,22 +2160,36 @@
         // Build the full-viewport wrap. Reuse the #splitscreen-wrap id so
         // any selectors elsewhere find it identically. We leave room at
         // the bottom for the follower toolbar.
+        //
+        // Block layout for single-panel mode, flex for multi-panel. With
+        // a single child at width/height: 100%, the flexbox algorithm
+        // doesn't reliably resolve the main-axis size — height: 100%
+        // can collapse to the child's content height. That made the
+        // panelDiv bounding rect 0-tall on first measure, the bar
+        // (position:absolute; bottom:0) got clipped by the panel's
+        // overflow:hidden, and the per-panel control bar appeared
+        // missing. Block positioning (matches the original
+        // buildFollowerPanel behavior) sizes height: 100% against the
+        // position:fixed parent's definite dimensions cleanly. Multi-
+        // panel layouts use 50% sizes which the flex algorithm resolves
+        // fine, so they keep the flex container.
         const followerWrap = document.createElement('div');
         followerWrap.id = 'splitscreen-wrap';
         followerWrap.style.cssText =
             'position:fixed;top:0;left:0;right:0;bottom:' + FOLLOWER_TOOLBAR_H + 'px;' +
-            'background:#000;z-index:9999;display:flex;';
+            'background:#000;z-index:9999;';
         if (layoutKey === 'top-bottom') {
+            followerWrap.style.display = 'flex';
             followerWrap.style.flexDirection = 'column';
         } else if (layoutKey === 'left-right') {
+            followerWrap.style.display = 'flex';
             followerWrap.style.flexDirection = 'row';
         } else if (layoutKey === 'quad') {
+            followerWrap.style.display = 'flex';
             followerWrap.style.flexDirection = 'row';
             followerWrap.style.flexWrap = 'wrap';
-        } else {
-            // single (follower)
-            followerWrap.style.flexDirection = 'column';
         }
+        // else: single (follower) — leave as block layout (no flex).
         document.body.appendChild(followerWrap);
         wrap = followerWrap;
 


### PR DESCRIPTION
## Summary

Two bugs introduced by the 1.3.0 multi-layout-popup refactor (#32) made the per-panel mini control bar invisible inside popped-out windows. Bug #1 hit single-panel popups on initial render; bug #2 hit every layout on window resize. They compounded — the second one masked the fact that even after the first fix, a popup user couldn't keep the bar around for long.

## Bug 1 — Single-panel popup, initial render

`buildFollowerLayout` set the wrap to `display:flex` for every layout, including single-panel mode. With one flex child at `width:100%; height:100%`, the flex algorithm doesn't reliably resolve the main-axis size — the panelDiv's height collapses to its content size (≈0) instead of filling the parent's definite height. The bar at `position:absolute; bottom:0` then gets clipped by the panel's `overflow:hidden`, so the bar appears missing on first paint.

Multi-panel layouts dodged this because their panels use `50%` sizes, which the flex algorithm resolves cleanly.

**Fix:** keep block layout (no `display:flex`) on the wrap when the layout is `'follower'`. Multi-panel layouts still use flex. This mirrors the original `buildFollowerPanel` positioning model from 1.2.0 (which used `position:fixed; inset:0` with no flex).

## Bug 2 — Window resize, every popup layout

The IIFE registers a global resize listener:

```js
window.addEventListener('resize', () => {
    if (active) sizeCanvases();
});
```

This is registered unconditionally and fires inside follower windows too. `sizeCanvases` is a main-window helper — it reads `#player-controls.offsetHeight` to compute the wrap's bottom offset:

```js
wrap.style.bottom = controlsH + 'px';
```

In a popup, `#player-controls` is force-hidden via the `bootFollowerMode` CSS rule (`display:none !important`), so `offsetHeight` returns 0. That overwrites the followerWrap's `bottom: FOLLOWER_TOOLBAR_H` (32px) reservation with `bottom: 0`, sliding the wrap to cover the entire viewport — directly behind the follower toolbar. Wrap is `z-index:9999`; toolbar is `z-index:10001`. The panel's bar at `position:absolute; bottom:0` is now at the very bottom of the viewport, fully covered by the toolbar.

This explained why initial render worked after Bug 1 was fixed but resize broke it: `buildFollowerLayout` sets `bottom:32px` and only calls `p.hw.resize()` directly (not `sizeCanvases`) on initial bootstrap, so the wrap is correct on first paint. The first window resize triggers `sizeCanvases` which clobbers it.

**Fix:** gate the global listener with `!FOLLOWER` so it skips popup windows. The follower-specific resize listener in `bootFollowerMode` already handles popup resizes correctly.

## Bonus fix — Multi-panel popup resize was incomplete

While in the area, I noticed the follower-specific resize listener was:

```js
window.addEventListener('resize', () => {
    if (panels[0]) panels[0].hw.resize();
});
```

Only `panels[0]` got resized. Multi-panel popups (top-bottom, left-right, quad) would leave panels 1, 2, 3 sized to their stale dimensions on window resize. Same shape bug for jumping-tab panes, which need `jumpingTabPane.resize()` instead of `hw.resize()`.

**Fix:** walk every panel using the same loop shape `sizeCanvases` uses (`if jumpingTabMode then jt.resize() else hw.resize()`). No one had hit this in practice because the Bug 2 wrap-clobber would already have hidden all the bars at that point — but it would have manifested the moment Bug 2 was fixed.

## Test plan

- [x] Pop a panel out (any mode: 2D, 3D, JT, lyrics). Per-panel control bar visible at bottom of popup window.
- [x] Resize the popup window. Bar stays visible.
- [x] Switch popup layout to Top/Bottom or Quad via the bottom toolbar. All bars visible.
- [x] Resize the popup window in multi-panel layout. All bars stay visible AND all panels resize correctly (canvas/JT pane fills its slot).
- [x] Switch back to Single. Bar visible. Resize. Bar still visible.
- [x] Dock the popup back. Main window unaffected.
- [x] Cycle a popup panel through 2D → 3D → JT → 2D modes; resize between each. Bar stays visible at every step.
- [x] Run the same flow on a smaller popup window (e.g. drag it to ~600x300). Bar should remain functional.

## Files

- [screen.js](https://github.com/topkoa/slopsmith-plugin-splitscreen/blob/fix/follower-single-panel-bar/screen.js) — three small surgical changes:
  - `buildFollowerLayout` wrap setup (drop `display:flex` for single-panel)
  - global resize listener (gate with `!FOLLOWER`)
  - `bootFollowerMode` resize listener (walk all panels, JT-aware)
- [plugin.json](https://github.com/topkoa/slopsmith-plugin-splitscreen/blob/fix/follower-single-panel-bar/plugin.json) — version bump 1.3.0 → 1.3.1.