### PR TITLE
feat: song-change toast in popup windows (1.4.0)

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "splitscreen",
   "name": "Split Screen",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "private": false,
   "settings": { "html": "settings.html" },
   "script": "screen.js"

--- a/screen.js
+++ b/screen.js
@@ -2256,6 +2256,8 @@
                     for (const p of panels) {
                         if (!p.lyricsMode && !p.jumpingTabMode) p.hw.setTime(msg.t);
                     }
+                    // Song-change toast lingers until playback begins.
+                    _maybeDismissFollowerToastOnPlay(msg.t);
                 } else if (msg.type === 'song-changed' && msg.filename && msg.filename !== currentFilename) {
                     _handleFollowerSongChange(msg.filename);
                 }
@@ -2373,6 +2375,166 @@
         teardownPanels();
         active = false;
         await loadSongInFollower(newFilename, cfgs);
+        // Briefly surface what the new song is so the popup viewer
+        // (often on a second monitor, away from the main window's HUD)
+        // sees the title / artist / tuning / per-panel arrangement
+        // before notes start scrolling.
+        _showFollowerSongToast(highway.getSongInfo());
+    }
+
+    // ── Song-change toast (popup only) ────────────────────────────────
+    // An overlay shown right after _handleFollowerSongChange finishes
+    // rebuilding the panels. Stays visible until the main window starts
+    // playback (detected by time-broadcasts advancing past the baseline
+    // captured at toast-creation). Replaces any prior toast in flight
+    // so a rapid sequence of song changes doesn't pile up.
+    const FOLLOWER_TOAST_FADE_MS = 400;
+    // Time threshold (seconds) the broadcast `t` must exceed beyond the
+    // baseline captured when the toast was shown, before we treat the
+    // song as "started." 50ms covers floating-point slop and the 60Hz
+    // broadcast interval (~17ms) without flapping.
+    const FOLLOWER_TOAST_PLAY_THRESHOLD_S = 0.05;
+    let _followerToast = null;
+    let _followerToastBaselineTime = 0;
+
+    // Common-tuning name resolver. Order-agnostic — works whether the
+    // tuning array is high-to-low or low-to-high (we test both ends for
+    // the drop pattern). Returns null for anything that isn't a flat
+    // uniform offset or a one-string drop variant; the caller falls
+    // back to displaying raw offsets in that case.
+    function _resolveFollowerTuningName(tuning) {
+        if (!Array.isArray(tuning) || tuning.length === 0) return null;
+        const STANDARD_NAMES = {
+            '0':  'E Standard',
+            '-1': 'Eb Standard',
+            '-2': 'D Standard',
+            '-3': 'C# Standard',
+            '-4': 'C Standard',
+            '2':  'F# Standard',
+        };
+        const DROP_NAMES = {
+            '0':  'Drop D',
+            '-1': 'Drop Db',
+            '-2': 'Drop C',
+            '-3': 'Drop B',
+            '-4': 'Drop Bb',
+        };
+        const allEqual = tuning.every(t => t === tuning[0]);
+        if (allEqual) return STANDARD_NAMES[String(tuning[0])] || null;
+        // One-string drop: low string is 2 semitones below an otherwise-
+        // uniform offset. Test both possible orientations of the array.
+        const last = tuning.length - 1;
+        const headEqual = tuning.slice(0, last).every(t => t === tuning[0]);
+        if (headEqual && tuning[last] === tuning[0] - 2) {
+            return DROP_NAMES[String(tuning[0])] || null;
+        }
+        const tail = tuning.slice(1);
+        const tailEqual = tail.every(t => t === tail[0]);
+        if (tailEqual && tuning[0] === tail[0] - 2) {
+            return DROP_NAMES[String(tail[0])] || null;
+        }
+        return null;
+    }
+
+    function _dismissFollowerToast() {
+        if (!_followerToast) return;
+        const toast = _followerToast;
+        toast.style.opacity = '0';
+        toast.style.transform = 'translateX(-50%) translateY(-12px)';
+        setTimeout(() => {
+            if (_followerToast === toast) _followerToast = null;
+            toast.remove();
+        }, FOLLOWER_TOAST_FADE_MS);
+    }
+
+    // Called from the time-broadcast handler. Dismisses the toast the
+    // first time the main window's audio.currentTime advances past the
+    // baseline captured at toast-creation — i.e. play has actually
+    // started. While main is paused at the new song's start (t = 0),
+    // every broadcast carries the same t and the toast stays visible.
+    function _maybeDismissFollowerToastOnPlay(t) {
+        if (!_followerToast) return;
+        if (t > _followerToastBaselineTime + FOLLOWER_TOAST_PLAY_THRESHOLD_S) {
+            _dismissFollowerToast();
+        }
+    }
+
+    function _showFollowerSongToast(info) {
+        if (!info) return;
+        // Replace any existing toast (rapid song-change sequence).
+        if (_followerToast) { _followerToast.remove(); _followerToast = null; }
+
+        const toast = document.createElement('div');
+        toast.id = 'follower-song-toast';
+        toast.style.cssText =
+            'position:fixed;top:24px;left:50%;' +
+            'transform:translateX(-50%) translateY(-12px);' +
+            'min-width:280px;max-width:80vw;padding:14px 22px;' +
+            'background:rgba(8,8,16,0.95);border:1px solid #4080e0;border-radius:8px;' +
+            'box-shadow:0 6px 20px rgba(0,0,0,0.55);' +
+            'z-index:10002;font-family:sans-serif;color:#e5e7eb;text-align:center;' +
+            'opacity:0;transition:opacity ' + FOLLOWER_TOAST_FADE_MS + 'ms ease,' +
+            'transform ' + FOLLOWER_TOAST_FADE_MS + 'ms ease;' +
+            'pointer-events:none;';
+
+        const title = document.createElement('div');
+        title.style.cssText = 'font-size:18px;font-weight:600;color:#fff;line-height:1.25;';
+        title.textContent = info.title || 'Untitled';
+        toast.appendChild(title);
+
+        if (info.artist) {
+            const artist = document.createElement('div');
+            artist.style.cssText = 'font-size:13px;color:#9ca3af;margin-top:2px;';
+            artist.textContent = info.artist;
+            toast.appendChild(artist);
+        }
+
+        const detailLines = [];
+        const tuningName = _resolveFollowerTuningName(info.tuning);
+        if (tuningName) detailLines.push('Tuning: ' + tuningName);
+        else if (Array.isArray(info.tuning) && info.tuning.length > 0) {
+            detailLines.push('Tuning: [' + info.tuning.join(', ') + ']');
+        }
+        if (Number.isFinite(info.capo) && info.capo > 0) detailLines.push('Capo: ' + info.capo);
+
+        if (detailLines.length > 0) {
+            const details = document.createElement('div');
+            details.style.cssText = 'font-size:12px;color:#9ca3af;margin-top:8px;line-height:1.5;';
+            details.textContent = detailLines.join(' · ');
+            toast.appendChild(details);
+        }
+
+        // Per-panel arrangement breakdown — only shown when there are 2+
+        // panels in the popup, since a single panel is self-evident
+        // from the highway already visible behind the toast.
+        if (panels.length > 1) {
+            const panelInfo = document.createElement('div');
+            panelInfo.style.cssText = 'font-size:11px;color:#9ca3af;margin-top:6px;line-height:1.4;';
+            const panelLabels = panels.map((p, idx) => {
+                const arrName = arrangements[p.arrIndex]?.name || 'Arr ' + p.arrIndex;
+                const modeSuffix = p.lyricsMode ? ' (Lyrics)'
+                    : p.jumpingTabMode ? ' (JT)'
+                    : p.hw3dMode ? ' (3D)'
+                    : '';
+                return 'P' + (idx + 1) + ': ' + arrName + modeSuffix;
+            });
+            panelInfo.textContent = panelLabels.join(' · ');
+            toast.appendChild(panelInfo);
+        }
+
+        document.body.appendChild(toast);
+        _followerToast = toast;
+        // Snapshot the current broadcast time so we can detect playback
+        // starting later. While main is paused, time messages keep
+        // arriving with this same value and the toast stays visible.
+        _followerToastBaselineTime = _followerCurrentTime;
+
+        // Animate in next frame so the initial opacity:0 / translateY
+        // styles take effect before the transition kicks in.
+        requestAnimationFrame(() => {
+            toast.style.opacity = '1';
+            toast.style.transform = 'translateX(-50%) translateY(0)';
+        });
     }
 
     // Kick off follower-mode bootstrap — placed at the very end of the IIFE


### PR DESCRIPTION
## Summary

Builds on 1.3.x's auto-follow-on-song-change feature: when the main window switches songs, popped-out windows already rebuild their panels for the new song without closing — but the viewer, often on a second monitor with the main HUD out of sight, had no indication of *what* just changed before notes started scrolling.

This PR adds a transient overlay that appears in every popup the moment the rebuild completes and stays visible until playback actually starts in the main window.

## What it shows

- **Title** (large, white) + **artist** (smaller, grey)
- **Tuning** — resolved to a friendly name when it matches a common pattern (E/Eb/D/C#/C Standard, Drop D/Db/C/B/Bb), or raw semitone offsets like `[0, 0, 0, 0, 0, -2]` as a fallback
- **Capo** fret (only when > 0)
- **Per-panel arrangement breakdown** — `P1: Lead · P2: Rhythm · P3: Bass`, with mode suffixes for Lyrics / JT / 3D, only rendered when there are 2+ panels (single-panel popups don't need it — the panel itself is self-evident)

## How dismissal works

The popup gets continuous `time` broadcasts at 60Hz from the main window. The toast captures the current broadcast time at toast-creation as a baseline, then dismisses itself the first time a subsequent broadcast carries `t > baseline + 0.05s`. While main is paused at the new song's `t = 0`, broadcasts keep arriving with `t = 0` and the toast stays. The moment the user presses play in main, `audio.currentTime` advances past the baseline and the toast fades out.

The 50ms threshold:
- Floating-point slop in `audio.currentTime` is sub-millisecond.
- The 60Hz broadcast interval is ~17ms.
- 50ms safely covers both without ever flapping or dismissing prematurely.

## Tuning resolver

Order-agnostic — the drop-pattern check tests both ends of the array, so it identifies Drop D whether the tuning is serialised low-to-high (`[-2, 0, 0, 0, 0, 0]`) or high-to-low (`[0, 0, 0, 0, 0, -2]`). Anything that isn't a flat uniform offset or a one-string-down-2 drop variant falls back to displaying the raw offset array, which is honest and informative for exotic tunings without trying to be clever.

## Edge cases

- **Rapid song changes** — each new song-change replaces the existing toast and resets the baseline. No stacking.
- **Song change while main is mid-playback** — `playSong` resets `audio.currentTime` to 0, so the baseline is 0 and the toast behaves normally.
- **Toast appears mid-playback** (rare race where main was already playing while popup was still rebuilding) — baseline gets captured at the already-advanced `t`, the next broadcast (~17ms later) advances past `baseline + 0.05`, so the toast briefly flashes and dismisses. That's the cost of strict ""dismiss on play"" semantics with no minimum-display-time.
- **No toast on initial popup boot** — only fires from `_handleFollowerSongChange`, not from `loadSongInFollower` directly. The user just popped out; they know what they're looking at.
- **Multi-popup** — each popup window has its own IIFE state, so each maintains its own toast and baseline independently.

## Implementation notes

- Toast is `z-index: 10002` (above the follower toolbar at 10001) and `pointer-events: none` so it doesn't block any UI underneath.
- Centered with `position: fixed; top: 24px; left: 50%; transform: translateX(-50%)`.
- Fade-in via `opacity` + `transform` transition (400ms ease).
- Replaces any prior toast on rapid song-change so we never pile up.
- All toast logic lives inside the single splitscreen IIFE; no new imports, no external state.

## Test plan

- [x] Pop a panel out. Change song in main while paused. Toast appears in popup with title/artist/tuning/capo. Press play in main → toast fades out.
- [x] Single-panel popup: toast doesn't show the per-panel breakdown.
- [x] Multi-panel popup (Top/Bottom, Left/Right, Quad): toast shows `P1: ... · P2: ...` etc.
- [x] Mixed panel modes in a popup (e.g. one 3D, one JT, one Lyrics): mode suffixes render correctly.
- [x] Song with E Standard / Drop D / Eb Standard tunings — verify named display.
- [x] Song with a non-standard tuning — verify raw-offset fallback.
- [x] Song with capo — verify capo line shows; song without capo — line absent.
- [x] Rapid song changes (advance 3-4 songs without pressing play): toast updates each time, no stacking.
- [x] Change song, wait ~30 seconds without pressing play: toast stays put.
- [x] Two popups open simultaneously: each gets its own toast, dismissed independently.
- [x] Resize popup window while toast is visible: toast stays centered and visible.

## Files

- [screen.js](https://github.com/topkoa/slopsmith-plugin-splitscreen/blob/feat/follower-song-change-toast/screen.js) — `_resolveFollowerTuningName`, `_showFollowerSongToast`, `_dismissFollowerToast`, `_maybeDismissFollowerToastOnPlay` helpers; toast call inside `_handleFollowerSongChange`; play-detection hook inside the broadcast-channel time handler.
- [plugin.json](https://github.com/topkoa/slopsmith-plugin-splitscreen/blob/feat/follower-song-change-toast/plugin.json) — version bump 1.3.1 → 1.4.0.