### PR TITLE
fix: clear vizMode flag when switching to Lyrics or Jumping Tab

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "splitscreen",
   "name": "Split Screen",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": false,
   "settings": { "html": "settings.html" },
   "script": "screen.js"

--- a/screen.js
+++ b/screen.js
@@ -964,6 +964,7 @@
     function enterLyricsMode(panel) {
         if (panel.lyricsMode) return;
 
+        if (panel.vizMode) exitVizMode(panel, panel.arrIndex);
         if (panel.jumpingTabMode) exitJumpingTabMode(panel, panel.arrIndex);
         if (panel.tabActive) togglePanelTab(panel);
         panel.hw.stop();
@@ -1016,6 +1017,7 @@
     function enterJumpingTabMode(panel) {
         if (panel.jumpingTabMode) return;
 
+        if (panel.vizMode) exitVizMode(panel, panel.arrIndex);
         if (panel.lyricsMode) exitLyricsMode(panel, panel.arrIndex);
         if (panel.tabActive) togglePanelTab(panel);
         panel.hw.stop();


### PR DESCRIPTION
## Summary
- Fixes panel mode persistence bug: piano (or any viz) panel switched to Lyrics or Jumping Tab would restore as the prior viz on next song open.
- Root cause: `enterLyricsMode` / `enterJumpingTabMode` did not exit active viz mode, so `panel.vizMode` remained set. `savePanelPrefs` checks `vizMode` before `lyricsMode`/`jumpingTabMode`, serializing as `__viz__:<id>:<arr>`.
- Mirror `enterVizMode`'s pattern: exit other active modes first.
- Version bump 1.5.0 -> 1.5.1.

## Test plan
- [x] Open song, splitscreen, set panel to Piano viz, switch panel to Lyrics, close song, reopen — panel restores as Lyrics
- [x] Same flow with Jumping Tab in place of Lyrics
- [x] Sanity: viz<->viz, viz<->arrangement, lyrics<->arrangement still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)