### PR TITLE
fix: sync built-in lyricsVisible flag on init for all panel modes

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "splitscreen",
   "name": "Split Screen",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": false,
   "settings": { "html": "settings.html" },
   "script": "screen.js"

--- a/screen.js
+++ b/screen.js
@@ -1371,8 +1371,12 @@
             }
             panel.updateLyricsStyle(on);
         };
-        if (panel.lyricsOverlayOn) _toggleLyricsOverlay(true);
-        else panel.updateLyricsStyle(false);
+        // Always invoke _toggleLyricsOverlay so the highway's built-in
+        // lyricsVisible flag (which feeds bundle.lyricsVisible consumed by
+        // viz renderers like 3D highway) is synced to the saved toggle
+        // state. Without this, viz panels with overlay off would still
+        // render lyrics because the built-in flag defaults to true.
+        _toggleLyricsOverlay(panel.lyricsOverlayOn);
         panel.lyricsBtn.onclick = () => {
             panel.lyricsOverlayOn = !panel.lyricsOverlayOn;
             _toggleLyricsOverlay(panel.lyricsOverlayOn);


### PR DESCRIPTION
## Summary
- Fixes lyrics toggle showing OFF while viz panels (3D highway etc.) still render lyrics on splitscreen open.
- Root cause: `initPanel`'s lyrics-overlay restore took the off path via `else panel.updateLyricsStyle(false)` — updates button style but never calls `panel.hw.setLyricsVisible(false)`. Highway's built-in `lyricsVisible` defaults to true and feeds `bundle.lyricsVisible` consumed by viz renderers.
- Fix: always invoke `_toggleLyricsOverlay(panel.lyricsOverlayOn)` on init so the built-in flag is synced for both on and off states.
- Version bump 1.5.1 -> 1.5.2.

## Test plan
- [x] Open song with viz panel (3D highway), toggle Lyrics OFF, close song, reopen — panel renders without lyrics
- [x] Same flow with toggle ON — overlay band appears, persists across reload
- [x] 2D non-viz panels still respect saved toggle on reopen

🤖 Generated with [Claude Code](https://claude.com/claude-code)