### PR TITLE
feat: persist split-screen on-state across browser sessions

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "splitscreen",
   "name": "Split Screen",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "private": false,
   "settings": { "html": "settings.html" },
   "script": "screen.js"

--- a/screen.js
+++ b/screen.js
@@ -26,7 +26,6 @@
     let active = false;
     let controlsHidden = false;
     let layout = localStorage.getItem('splitscreenLayout') || 'top-bottom';
-    let autoReactivate = localStorage.getItem('splitscreenAutoReactivate') === 'true';
     let alwaysSplit = localStorage.getItem('splitscreenAlwaysSplit') === 'true';
     let panels = [];       // { hw, canvas, ws, arrIndex, controls }
     let wrap = null;
@@ -222,15 +221,6 @@
             layout = layoutSelect.value;
             localStorage.setItem('splitscreenLayout', layout);
             if (active) rebuildLayout();
-        });
-    }
-
-    const autoReactivateCheckbox = document.getElementById('splitscreen-auto-reactivate');
-    if (autoReactivateCheckbox) {
-        autoReactivateCheckbox.checked = autoReactivate;
-        autoReactivateCheckbox.addEventListener('change', () => {
-            autoReactivate = autoReactivateCheckbox.checked;
-            localStorage.setItem('splitscreenAutoReactivate', autoReactivate);
         });
     }
 
@@ -1809,6 +1799,7 @@
         // the renderer mounts to #player (main-player fast path) on the first
         // entry and is stuck full-screen until the next start cycle.
         active = true;
+        try { localStorage.setItem('splitscreenActive', 'true'); } catch (_) {}
         focusedPanelIdx = 0;
 
         // Size the wrap NOW so panelDivs have a real rect during initPanel.
@@ -1942,6 +1933,9 @@
     function toggle() {
         if (_starting) return; // treat in-flight start as already active
         if (active) {
+            // User-intent off — persist so navigation-driven stops (song
+            // switch, leaving player) don't erase the user's on-state.
+            try { localStorage.setItem('splitscreenActive', 'false'); } catch (_) {}
             stopSplitScreen();
         } else {
             startSplitScreen();
@@ -2267,7 +2261,10 @@
     // ── Hook into playSong ──
     const _play = window.playSong;
     window.playSong = async function (f, a) {
-        const wasActive = active;
+        // OR in persisted active flag so split state carries across page
+        // loads — without this, `active` resets to false on reload and the
+        // user's prior split session is forgotten.
+        const wasActive = active || localStorage.getItem('splitscreenActive') === 'true';
         // In a follower window, never auto-stop split — the follower panel IS
         // the only thing on screen, and we drive its setup ourselves.
         if (!FOLLOWER && active) stopSplitScreen();
@@ -2296,14 +2293,14 @@
                 ssChannel.postMessage({ type: 'song-changed', filename: currentFilename });
             }
 
-            if (!handled && !FOLLOWER && (alwaysSplit || (wasActive && autoReactivate))) {
+            if (!handled && !FOLLOWER && (alwaysSplit || wasActive)) {
                 handled = true;
                 startSplitScreen();
             }
         };
 
         // Fallback: poll for song info in case _onReady was missed
-        if (!FOLLOWER && (alwaysSplit || (wasActive && autoReactivate))) {
+        if (!FOLLOWER && (alwaysSplit || wasActive)) {
             let attempts = 0;
             const poll = setInterval(() => {
                 attempts++;

--- a/settings.html
+++ b/settings.html
@@ -15,11 +15,4 @@
         </label>
         <span class="text-xs text-gray-500">Automatically split every song on play</span>
     </div>
-    <div class="flex items-center gap-3 mt-3">
-        <label class="text-sm text-gray-300 cursor-pointer flex items-center gap-2">
-            <input type="checkbox" id="splitscreen-auto-reactivate" class="accent-blue-500 w-4 h-4">
-            Remember split screen between songs
-        </label>
-        <span class="text-xs text-gray-500">Re-enter split with your panel preferences when switching songs</span>
-    </div>
 </div>


### PR DESCRIPTION
## Summary
- Splitscreen now remembers what the user last did across browser reloads and song changes — open a song, enable split, exit, reopen → split resumes automatically.
- Persistence model: `startSplitScreen` writes `splitscreenActive=true`; `toggle()`'s off-branch writes `false`. Navigation-driven stops (`showScreen` leaving player, `playSong` switching songs) preserve the persisted value so internal teardowns don't erase user intent.
- Drops the now-redundant `autoReactivate` checkbox + storage key. Persisted state encodes user intent directly. `alwaysSplit` checkbox unchanged for the force-on-every-song use case.
- Version bump 1.5.2 -> 1.6.0.

## Test plan
- [x] Force-on off, open song, enable Split, exit to library, reopen song — split auto-resumes
- [x] Click Split off (toggle), exit, reopen — no resume
- [x] Force-on still triggers split on every song
- [x] Settings panel shows only layout dropdown + always-split checkbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)