### PR TITLE
Use highway:visibility contract instead of hand-hiding viz overlays

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,7 +274,7 @@ The plugin wraps `window.playSong` to:
 - Core emits `highway:visibility` (`{ visible, canvas }` on `event.detail`) on transitions. Viz renderers that mount **sibling DOM** — e.g. 3D Highway's `.h3d-wrap` overlay, a sibling of `#highway` that `display:none` on the canvas doesn't cover — subscribe to that event (filtered by canvas identity, so splitscreen's per-panel instances don't toggle each other) and hide/show their own overlays. Splitscreen used to hand-hunt `:scope > .h3d-wrap` siblings of `#highway` and toggle them itself; that's gone — the viz owns its overlay's visibility now.
 - Per-panel viz overlays don't need special handling: exiting viz mode on a panel (`exitVizMode` → `recreatePanelHighway`) discards the panel highway, which calls the renderer's `destroy()` and removes its overlay. A panel canvas hidden for lyrics/jumping-tab mode has no live viz renderer to leave anything painting.
 
-Requires a core build with the `highway:visibility` API (~slopsmith 0.2.7.1+). On an older core, `display:none` still pauses nothing extra and a sibling-mounting viz overlay (3D Highway) may bleed through the panels — update both together.
+Wants a core with the `highway:visibility` API (~slopsmith 0.2.7.1+) for the rAF skip and the overlay auto-hide — not a hard dependency. On an older core the plugin still runs; `display:none` on `#highway` just doesn't pause the hidden highway's draw loop, and a sibling-mounting viz overlay (3D Highway) may bleed through the panels. Update both together to fix that.
 
 ## External plugin integration points
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,7 +252,7 @@ The plugin wraps `window.playSong` to:
 
 ```
 #player  (position:fixed, inset:0, z-index:100)
-  #highway              — default highway canvas, hidden when splitscreen active
+  #highway              — default highway canvas, hidden (display:none) when splitscreen active
   #splitscreen-wrap     — position:absolute, top:0, left:0, right:0, bottom:{controlsH}px, z-index:3
     .splitscreen-panel  — each panel, position:relative, overflow:hidden
       <canvas>          — the highway canvas
@@ -265,6 +265,16 @@ The plugin wraps `window.playSong` to:
   #player-controls      — position:relative, z-index:10, margin-top:auto (while splitscreen active)
   [floatBtn]            — position:absolute, bottom:8px, right:8px, z-index:20 (when bar hidden)
 ```
+
+### Hiding `#highway` and the `highway:visibility` contract
+
+`startSplitScreen()` hides `#highway` with `display:none`; `stopSplitScreen()` (and the start-failure rollback) restores it. That single hide is all splitscreen does — core does the rest (slopsmith#246):
+
+- Core's rAF reads `canvas.offsetParent === null` per tick. While the canvas is hidden it skips the highway's `renderer.draw()` (and the default 2D draw), so the hidden main highway isn't burning frames behind the panels.
+- Core emits `highway:visibility` (`{ visible, canvas }` on `event.detail`) on transitions. Viz renderers that mount **sibling DOM** — e.g. 3D Highway's `.h3d-wrap` overlay, a sibling of `#highway` that `display:none` on the canvas doesn't cover — subscribe to that event (filtered by canvas identity, so splitscreen's per-panel instances don't toggle each other) and hide/show their own overlays. Splitscreen used to hand-hunt `:scope > .h3d-wrap` siblings of `#highway` and toggle them itself; that's gone — the viz owns its overlay's visibility now.
+- Per-panel viz overlays don't need special handling: exiting viz mode on a panel (`exitVizMode` → `recreatePanelHighway`) discards the panel highway, which calls the renderer's `destroy()` and removes its overlay. A panel canvas hidden for lyrics/jumping-tab mode has no live viz renderer to leave anything painting.
+
+Requires a core build with the `highway:visibility` API (~slopsmith 0.2.7.1+). On an older core, `display:none` still pauses nothing extra and a sibling-mounting viz overlay (3D Highway) may bleed through the panels — update both together.
 
 ## External plugin integration points
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ git clone https://github.com/topkoa/slopsmith-plugin-splitscreen.git splitscreen
 docker compose restart
 ```
 
-**Requires** a Slopsmith core with the `highway:visibility` plugin API (~0.2.7.1+). On older cores splitscreen still works, but a visualization plugin that mounts a sibling overlay — e.g. the 3D Highway's WebGL overlay — may bleed through the panels while splitscreen is active; update the core (and the 3D Highway plugin) to fix it.
+**Compatibility** — splitscreen runs on any Slopsmith core. On cores with the `highway:visibility` plugin API (~0.2.7.1+), a visualization plugin that mounts a sibling overlay — e.g. the 3D Highway's WebGL overlay — hides itself cleanly while splitscreen is active. On older cores that overlay may bleed through the panels; update the core (and the 3D Highway plugin) to fix it.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ git clone https://github.com/topkoa/slopsmith-plugin-splitscreen.git splitscreen
 docker compose restart
 ```
 
+**Requires** a Slopsmith core with the `highway:visibility` plugin API (~0.2.7.1+). On older cores splitscreen still works, but a visualization plugin that mounts a sibling overlay — e.g. the 3D Highway's WebGL overlay — may bleed through the panels while splitscreen is active; update the core (and the 3D Highway plugin) to fix it.
+
 ## Usage
 
 1. Open any song in the player.

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "splitscreen",
   "name": "Split Screen",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "private": false,
   "settings": { "html": "settings.html" },
   "script": "screen.js"

--- a/screen.js
+++ b/screen.js
@@ -34,10 +34,6 @@
     let vizPlugins   = []; // {id, name, ...} — type=visualization plugins from /api/plugins
     let _starting    = false; // re-entrancy guard for startSplitScreen
     let _pendingRebuild = false; // rebuildLayout requested while a start is in flight
-    // Viz overlays (e.g. 3D Highway's .h3d-wrap) that live as siblings of
-    // #highway and aren't hidden by display:none on the canvas alone. Hidden
-    // while split is active; entries are [el, prevInlineDisplay].
-    let _hiddenHighwaySiblings = [];
 
     // Core swaps a panel's <canvas> element when a renderer needs a different
     // context type than the one the canvas is bound to (browsers lock a canvas
@@ -1992,26 +1988,18 @@
             if (panelPrefs?.barHidden) togglePanelBar(panel);
         }
 
-        // Hide default highway canvas, ensure controls stay on top and at bottom
+        // Hide default highway canvas, ensure controls stay on top and at bottom.
+        // Core detects the hide via canvas.offsetParent === null (slopsmith#246):
+        // it pauses the main highway's rAF draw AND emits `highway:visibility`
+        // on window.slopsmith. Viz renderers that mount sibling DOM — e.g. 3D
+        // Highway's .h3d-wrap overlay, a sibling of #highway that display:none
+        // on the canvas alone doesn't cover — subscribe to that event and hide
+        // their own overlays. Splitscreen no longer reaches into other plugins'
+        // DOM to do this; it just hides #highway and lets the contract handle
+        // the rest (on stop, restoring #highway re-emits visible → overlays
+        // re-show themselves).
         const defaultCanvas = document.getElementById('highway');
         if (defaultCanvas) defaultCanvas.style.display = 'none';
-        // Some viz renderers (3D Highway) don't draw on #highway — they mount an
-        // overlay <div class="h3d-wrap"> as a SIBLING of #highway and render a
-        // WebGL canvas inside it, with its own rAF loop. display:none on the
-        // canvas alone leaves that overlay rendering full-screen at z-index 2,
-        // behind #splitscreen-wrap (z-index 3) but visible through any panel
-        // gap (and, before the opaque-bar change above, through the bars).
-        // Hide every such sibling; restore on stop and on start-failure
-        // rollback. Restore-first so a rebuild (teardown + restart, which
-        // leaves the overlays hidden) doesn't capture 'none' as their
-        // pre-split display.
-        restoreHiddenHighwaySiblings();
-        if (defaultCanvas && defaultCanvas.parentNode) {
-            defaultCanvas.parentNode.querySelectorAll(':scope > .h3d-wrap').forEach((el) => {
-                _hiddenHighwaySiblings.push([el, el.style.display]);
-                el.style.display = 'none';
-            });
-        }
         const controls = document.getElementById('player-controls');
         if (controls) {
             controls.style.position = 'relative';  // Required for z-index to work
@@ -2050,7 +2038,6 @@
             restoreHud();
             const defaultCanvas = document.getElementById('highway');
             if (defaultCanvas) defaultCanvas.style.display = '';
-            restoreHiddenHighwaySiblings();
             const controls = document.getElementById('player-controls');
             if (controls) {
                 if (controlsHidden) controls.style.display = '';
@@ -2073,16 +2060,6 @@
         }
     }
 
-    // Restore the display of viz overlays (e.g. 3D Highway's .h3d-wrap) that
-    // startSplitScreen() hid because they're siblings of #highway and not
-    // covered by display:none on the canvas. Safe to call when nothing was hidden.
-    function restoreHiddenHighwaySiblings() {
-        for (const [el, prev] of _hiddenHighwaySiblings) {
-            if (el && el.isConnected) el.style.display = prev;
-        }
-        _hiddenHighwaySiblings = [];
-    }
-
     function stopSplitScreen() {
         savePanelPrefs();
         teardownPanels();  // flips active=false + emits focus change
@@ -2096,10 +2073,11 @@
         setRedundantControlsHidden(false);
         restoreHud();
 
-        // Restore default highway canvas, its sibling viz overlays, and controls z-index
+        // Restore default highway canvas (core re-emits `highway:visibility` →
+        // sibling-mounting viz overlays like 3D Highway's .h3d-wrap re-show
+        // themselves; see slopsmith#246) and controls z-index
         const defaultCanvas = document.getElementById('highway');
         if (defaultCanvas) defaultCanvas.style.display = '';
-        restoreHiddenHighwaySiblings();
         const controls = document.getElementById('player-controls');
         if (controls) {
             if (controlsHidden) controls.style.display = '';


### PR DESCRIPTION
## Summary

slopsmith#246 ([byrongamatos/slopsmith#252](https://github.com/byrongamatos/slopsmith/pull/252)) added a visibility contract to core:

- The highway's rAF loop now skips `renderer.draw()` (and the default 2D draw) while `canvas.offsetParent === null` — i.e. while splitscreen has `#highway` `display:none`. The hidden main highway no longer burns frames behind the panels.
- Core emits `highway:visibility` (`{ visible, canvas }` on `event.detail`) on transitions. Viz renderers that mount **sibling DOM** — e.g. 3D Highway's `.h3d-wrap` overlay, a sibling of `#highway` that `display:none` on the canvas doesn't cover — subscribe to that event (filtered by canvas identity, splitscreen-safe) and hide/show their own overlays.

This makes splitscreen's manual workaround redundant. It used to `querySelectorAll(':scope > .h3d-wrap')` on `#highway`'s parent and toggle those elements itself — reaching into another plugin's DOM by class name, with a restore-first-then-rehide flicker on layout rebuild.

## Changes

- **`screen.js`**: remove `_hiddenHighwaySiblings`, `restoreHiddenHighwaySiblings()`, the `:scope > .h3d-wrap` block in `startSplitScreen()`, and the restore calls in the start-failure rollback and `stopSplitScreen()`. Splitscreen now just hides/restores `#highway` and lets the contract do the rest (on stop, restoring `#highway` re-emits `visible` → overlays re-show themselves). Net code removal.
- **`CLAUDE.md`**: new "Hiding `#highway` and the `highway:visibility` contract" subsection; clarified DOM-structure line.
- **`README.md`**: notes the core version requirement (~0.2.7.1+); older cores still work but a sibling-mounting viz overlay may bleed through panels.

Per-panel viz overlays need no special handling — `exitVizMode` → `recreatePanelHighway` destroys the panel's renderer (removing its overlay) before any panel-canvas hide.

## Test plan

- `node --check screen.js` — passes.
- Manual: open a song with 3D Highway as the main viz → click Split → 3D WebGL overlay no longer bleeds through panels / behind bars. Click Split off → 3D highway returns. Set a panel to 3D Highway, switch it to Tab/Lyrics/Jumping Tab → no leftover 3D paint. Change layout while split active → no overlay bleed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)