### PR TITLE
feat: add guided tour (1.9.0)

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,8 +1,9 @@
 {
   "id": "splitscreen",
   "name": "Split Screen",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "private": false,
   "settings": { "html": "settings.html" },
-  "script": "screen.js"
+  "script": "screen.js",
+  "tour": "tour.json"
 }

--- a/tour.json
+++ b/tour.json
@@ -1,0 +1,73 @@
+{
+    "version": 1,
+    "tour": [
+        {
+            "id": "welcome",
+            "title": "Welcome to Split Screen",
+            "content": "Play one song through multiple views at once — different arrangements, lyrics, jumping tab, or a 3D Highway in one panel and the default 2D in another. Pop a panel into a second monitor if you have one.",
+            "shape": "bubble",
+            "position": "auto"
+        },
+        {
+            "id": "split-btn",
+            "selector": "#btn-splitscreen",
+            "title": "The Split button",
+            "content": "This toggles the split view. Click it now to see the panels.",
+            "shape": "spotlight",
+            "position": "top",
+            "advance": "click-target"
+        },
+        {
+            "id": "layout-picker",
+            "selector": "#splitscreen-layout-btn",
+            "title": "Pick a layout",
+            "content": "Top/bottom, left/right, or quad (four panels). Switch any time — your per-panel preferences carry over.",
+            "shape": "spotlight",
+            "position": "top"
+        },
+        {
+            "id": "panel",
+            "selector": ".splitscreen-panel",
+            "title": "A panel",
+            "content": "Each panel runs its own highway with its own WebSocket. The mini bar at the bottom controls just this panel — arrangement, viz, Invert, Lefty, Lyrics, Tab, Detect, audio channel, and pop-out.",
+            "shape": "spotlight",
+            "position": "auto"
+        },
+        {
+            "id": "modes",
+            "title": "Panel modes",
+            "content": "The arrangement dropdown in each panel's bar also picks a *mode*: any chart arrangement (Lead, Rhythm, Bass…), Lyrics, Jumping Tab, or a viz plugin you have installed (e.g. 3D Highway). Modes are mutually exclusive per panel.",
+            "shape": "bubble",
+            "position": "auto"
+        },
+        {
+            "id": "viz-settings",
+            "title": "Per-panel viz settings",
+            "content": "When a panel is running a viz that exposes per-panel controls (e.g. 3D Highway: palette, camera smoothing), a \"3D ⚙\" button appears in that panel's bar. Tweaks scope to that panel only — your global viz settings stay untouched.",
+            "shape": "bubble",
+            "position": "auto"
+        },
+        {
+            "id": "hide-bar",
+            "selector": "#btn-splitscreen-hide-bar",
+            "title": "Reclaim screen space",
+            "content": "Collapse the global controls bar to give the panels the full window height. A floating ▴ Controls pill brings it back. Each panel's own mini bar also has a ▾ Bar toggle in its bottom-right corner.",
+            "shape": "spotlight",
+            "position": "top"
+        },
+        {
+            "id": "pop-out",
+            "title": "Multi-monitor pop-out",
+            "content": "Click ⇱ Pop in a panel's bar to detach it into its own window — great for a second monitor. The popup stays in sync with the main player's playhead via BroadcastChannel. Click ⇲ Dock in the popup (or just close it) to bring the panel back.",
+            "shape": "bubble",
+            "position": "auto"
+        },
+        {
+            "id": "outro",
+            "title": "That's the tour",
+            "content": "Defaults live in Settings → Split Screen: default layout, auto-reactivate split after page reloads, or always-on split. Restart this tour any time with the ? button next to Split.",
+            "shape": "bubble",
+            "position": "auto"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- Adds `tour.json` — a 9-step Shepherd-driven tour walking new users through Split activation, the layout picker, panel anatomy, per-panel modes (lyrics / jumping tab / per-panel viz / tab overlay / Detect / audio channel), the per-panel viz settings popover (the "3D ⚙" button), the global controls-bar collapse, and the multi-monitor pop-out flow.
- Adds `"tour": "tour.json"` to `plugin.json` so slopsmith core's plugin loader sets `has_tour: true` on this plugin.
- Bumps `version` to 1.9.0 (minor — user-facing feature addition).

## Why
The companion slopsmith core PR consolidates every plugin's `?` trigger into one menu at the bottom-right of the viewport — so splitscreen just contributes its tour content + manifest field, no DOM injection in `screen.js`. The core takes care of injecting the button, gating it by screen relevance (this tour defaults to player), and firing the first-visit "Take a quick tour of Split Screen?" toast.

Requires the matching core change: byrongamatos/slopsmith#272.

## Test plan
- [x] On player screen, the consolidated `?` menu lists "Split Screen" with a NEW badge on first visit
- [x] Click → 9-step tour plays
- [x] Step 2 (`#btn-splitscreen`) auto-advances when Split is clicked
- [x] Selectors used in `tour.json` resolve (`#btn-splitscreen`, `#splitscreen-layout-btn`, `.splitscreen-panel`, `#btn-splitscreen-hide-bar`)
- [ ] After completing the tour, the badge switches to ✓
- [ ] Toast doesn't re-pop after dismissal

🤖 Generated with [Claude Code](https://claude.com/claude-code)