### PR TITLE
Repopulate the viz picker as late-loading factories arrive (1.9.2)

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "splitscreen",
   "name": "Split Screen",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "private": false,
   "settings": { "html": "settings.html" },
   "script": "screen.js",

--- a/screen.js
+++ b/screen.js
@@ -120,6 +120,67 @@
             .filter(k => k.startsWith('slopsmithViz_') && typeof window[k] === 'function')
             .map(k => ({ id: k.slice('slopsmithViz_'.length), name: k.slice('slopsmithViz_'.length) }));
     }
+
+    // Bounded poll for viz factories that register AFTER the picker is
+    // first built. /api/plugins returns metadata for every type:visualization
+    // plugin immediately, but each plugin's window.slopsmithViz_<id> factory
+    // only exists after the host has loaded and executed that plugin's
+    // screen.js. The host loads plugin scripts sequentially in loadPlugins()
+    // (alphabetical by directory). Two cases leave the picker missing
+    // entries when populateSelect() runs:
+    //   - Plugins alphabetically after 'splitscreen' (tab_view, tuner, …)
+    //     simply haven't been loaded yet when our IIFE runs.
+    //   - Async plugins (e.g. highway_3d's `await import(CDN)` for Three.js)
+    //     register their factory after their <script> onload fires, so even
+    //     an alphabetically-earlier plugin can lag.
+    // Without this watch, the picker stays incomplete until the user
+    // triggers another populateSelect (song change, layout change) — which
+    // is exactly why "split-then-unsplit in the popup" used to be the only
+    // way to surface the missing viz options.
+    const _seenVizFactoryIds = new Set();
+    let _vizFactoryWatchTimer = null;
+    function _startVizFactoryWatch() {
+        if (_vizFactoryWatchTimer) return;
+        // Seed with factories already present so the first tick only fires
+        // on factories that appear AFTER we start watching.
+        vizPlugins.forEach(vp => {
+            if (typeof window['slopsmithViz_' + vp.id] === 'function') {
+                _seenVizFactoryIds.add(vp.id);
+            }
+        });
+        const INTERVAL_MS = 200;
+        const MAX_TICKS = 60;       // ~12 s — covers slow async plugins
+        let ticks = 0;
+        _vizFactoryWatchTimer = setInterval(() => {
+            ticks++;
+            let added = false;
+            vizPlugins.forEach(vp => {
+                if (!_seenVizFactoryIds.has(vp.id) &&
+                    typeof window['slopsmithViz_' + vp.id] === 'function') {
+                    _seenVizFactoryIds.add(vp.id);
+                    added = true;
+                }
+            });
+            if (added) {
+                // Re-populate every live panel's picker so the new viz
+                // options become available. populateSelect honours each
+                // panel's vizMode / lyricsMode / jumpingTabMode + arrIndex,
+                // so the user's current selection is preserved across the
+                // rebuild.
+                panels.forEach(p => {
+                    if (p && p.select) populateSelect(p, p.arrIndex || 0);
+                });
+            }
+            const allPresent = vizPlugins.every(vp =>
+                typeof window['slopsmithViz_' + vp.id] === 'function'
+            );
+            if (allPresent || ticks >= MAX_TICKS) {
+                clearInterval(_vizFactoryWatchTimer);
+                _vizFactoryWatchTimer = null;
+            }
+        }, INTERVAL_MS);
+    }
+
     // Keep the promise so startSplitScreen / loadSongInFollower can await it —
     // panels are never populated before the list is ready even on a fast first
     // interaction.
@@ -1094,6 +1155,14 @@
                 panel.select.appendChild(opt);
             });
         });
+
+        // Any registered viz plugin whose factory hasn't loaded yet? Kick
+        // off the bounded poll so the picker auto-repopulates once their
+        // script registers window.slopsmithViz_<id>. Single-flight — cheap
+        // to call on every populateSelect.
+        if (vizPlugins.some(vp => typeof window['slopsmithViz_' + vp.id] !== 'function')) {
+            _startVizFactoryWatch();
+        }
     }
 
     function enterLyricsMode(panel) {


### PR DESCRIPTION
## Summary

`populateSelect()` filters viz options by whether `window.slopsmithViz_<id>` is a function *at the moment* the picker is built. The `/api/plugins` registry is fetched eagerly, but each viz plugin's factory only exists after the host's `loadPlugins()` has executed that plugin's `screen.js`. `loadPlugins()` loads plugin scripts sequentially in alphabetical order, so the picker drops:

- Plugins alphabetically after `splitscreen/` (tab_view, tuner, …), whose `<script>` hasn't run yet when our IIFE runs.
- Async plugins (e.g. `highway_3d`'s `await import(CDN)` for Three.js), which register their factory after their `<script>` onload fires.

In the main window the user normally hits Split well after page load, so all factories are registered by then. **In a freshly-popped follower window the picker is built immediately on `bootFollowerMode` → the same race surfaces** and the user sees only Lyrics + arrangement entries until they split-then-unsplit the popup (which triggers another `populateSelect`).

## Fix

Add a bounded poll (200 ms tick, ~12 s cap) that re-runs `populateSelect` on every live panel whenever a new `window.slopsmithViz_<id>` factory appears.

- **Single-flight.** Kicked off from the bottom of `populateSelect()` whenever any registered viz plugin's factory is still missing. Repeated calls are a no-op while the watch is running.
- **Seeds "already seen"** with whatever's present at start time, so the first rebuild only fires once new factories actually show up — no spurious initial rebuild.
- **Self-terminates** when all registered factories are present (covers the common case quickly), or when the tick budget expires (covers a plugin that errored out and never registers, so we don't poll forever).
- **Selection-preserving.** `populateSelect` honours each panel's `vizMode` / `lyricsMode` / `jumpingTabMode` + `arrIndex`, so the user's current selection survives the rebuild.

Bumps `plugin.json` version 1.9.1 → 1.9.2.

## Test plan

- [x] `node --check screen.js` clean
- [x] Pop out a panel on a fresh app launch — picker initially shows Lyrics + arrangement entries, then auto-repopulates within ~1–2s with all viz options as their factories register. No need to split-then-unsplit anymore.
- [x] Existing viz selection in a panel survives the auto-rebuild (panel doesn't reset to default).
- [ ] Main window: open a song, hit Split. Picker is fully populated immediately (the fast path — all factories have loaded long before the user clicks). Watch starts and self-terminates on the first tick since `allPresent` is already true.