### PR TITLE
Add tri-top and tri-bottom 3-panel layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A plugin for [Slopsmith](https://github.com/byrongamatos/slopsmith) that shows 2
 
 ## Features
 
-- **Three layouts** — Top/Bottom (2P), Left/Right (2P), and Quad (4P, 2×2 grid)
+- **Five layouts** — Top/Bottom (2P), Left/Right (2P), Tri 1+2 (3P, one on top + two on bottom), Tri 2+1 (3P, two on top + one on bottom), and Quad (4P, 2×2 grid)
 - **Per-panel arrangement selector** — each panel has its own dropdown; swap what it renders mid-playback without restarting the song
 - **Per-panel visualization picker** — each panel can independently run any installed `slopsmithViz` plugin (e.g. the 3D highway) alongside the default 2D highway
 - **Per-panel invert toggle** — flip individual panels between player and audience perspective independently
@@ -67,7 +67,7 @@ Every popup has a small toolbar pinned to its bottom edge with a **Layout** pick
 
 ## Settings
 
-Open **Settings → Split Screen** to pick the default layout (Top/Bottom, Left/Right, or Quad). The choice is stored in `localStorage` as `splitscreenLayout` and applies the next time you toggle split screen on.
+Open **Settings → Split Screen** to pick the default layout (Top/Bottom, Left/Right, Tri 1+2, Tri 2+1, or Quad). The choice is stored in `localStorage` as `splitscreenLayout` and applies the next time you toggle split screen on.
 
 ## Note Detection
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "splitscreen",
   "name": "Split Screen",
-  "version": "1.9.2",
+  "version": "1.10.0",
   "private": false,
   "settings": { "html": "settings.html" },
   "script": "screen.js",

--- a/screen.js
+++ b/screen.js
@@ -9,9 +9,11 @@
      * ====================================================================== */
 
     const LAYOUTS = {
-        'top-bottom': { panels: 2, style: 'flex-col' },
-        'left-right': { panels: 2, style: 'flex-row' },
-        'quad':       { panels: 4, style: 'grid-2x2' },
+        'top-bottom':  { panels: 2, style: 'flex-col' },
+        'left-right':  { panels: 2, style: 'flex-row' },
+        'tri-top':     { panels: 3, style: 'grid-tri' },
+        'tri-bottom':  { panels: 3, style: 'grid-tri' },
+        'quad':        { panels: 4, style: 'grid-2x2' },
     };
 
     const OFF_CLASS = 'px-3 py-1.5 bg-dark-600 hover:bg-dark-500 rounded-lg text-xs text-gray-300 transition';
@@ -686,6 +688,12 @@
         } else if (layoutKey === 'left-right') {
             panelDiv.style.width = '50%';
             panelDiv.style.height = '100%';
+        } else if (layoutKey === 'tri-top') {
+            panelDiv.style.width = index === 0 ? '100%' : '50%';
+            panelDiv.style.height = '50%';
+        } else if (layoutKey === 'tri-bottom') {
+            panelDiv.style.width = index === 2 ? '100%' : '50%';
+            panelDiv.style.height = '50%';
         } else if (layoutKey === 'follower') {
             panelDiv.style.width = '100%';
             panelDiv.style.height = '100%';
@@ -2404,9 +2412,11 @@
             'background:#1a1a2e;border:1px solid #333;border-radius:6px;' +
             'padding:3px 6px;font-size:11px;color:#9ca3af;outline:none;display:none;';
         const options = [
-            { value: 'top-bottom', label: '⬒ Top/Bottom' },
-            { value: 'left-right', label: '⬓ Left/Right' },
-            { value: 'quad', label: '⊞ Quad' },
+            { value: 'top-bottom',  label: '⬒ Top/Bottom' },
+            { value: 'left-right',  label: '⬓ Left/Right' },
+            { value: 'tri-top',     label: '⊤ 1+2' },
+            { value: 'tri-bottom',  label: '⊥ 2+1' },
+            { value: 'quad',        label: '⊞ Quad' },
         ];
         for (const o of options) {
             const opt = document.createElement('option');

--- a/settings.html
+++ b/settings.html
@@ -5,6 +5,8 @@
         <select id="splitscreen-default-layout" class="bg-dark-600 border border-gray-700 rounded-lg px-2 py-1.5 text-xs text-gray-300 outline-none">
             <option value="top-bottom">Top / Bottom (2P)</option>
             <option value="left-right">Left / Right (2P)</option>
+            <option value="tri-top">Tri — 1 Top / 2 Bottom (3P)</option>
+            <option value="tri-bottom">Tri — 2 Top / 1 Bottom (3P)</option>
             <option value="quad">Quad (4P)</option>
         </select>
     </div>


### PR DESCRIPTION
## Summary

Adds two new 3-panel layout modes to the splitscreen plugin:

- **`tri-top`** — 1 panel on top (full width), 2 panels on bottom (half width each). T-shape.
- **`tri-bottom`** — 2 panels on top (half width each), 1 panel on bottom (full width). Inverted-T.

Fills the gap between the existing 2-panel (`top-bottom`, `left-right`) and 4-panel (`quad`) layouts — useful for songs with three relevant arrangements (lead + rhythm + bass) without forcing a duplicate into a 4th cell.

## Implementation

- `LAYOUTS` const gains two entries with `panels: 3`.
- `createPanel` gains explicit branches for `tri-top` / `tri-bottom` with per-index sizing (50% / 100% width based on which panel is the solo). No nested flex containers — piggybacks on the existing `flex-row` + `flex-wrap` path already used by `quad`.
- Toolbar layout picker and Settings dropdown each get two new options.
- Bumps plugin version `1.9.2 → 1.10.0`.
- Reuses `getDefaultArrangements(3)` (already supports arbitrary panel counts → P1 = lead, P2 = rhythm, P3 = bass).

No changes needed to `applyLayoutStyle`, `startSplitScreen`, `getDefaultArrangements`, `sizeCanvases`, or panel-prefs migration — all are already data-driven on `cfg.panels`.

## Out of scope

- **Follower-window (popped-out) tri layouts** — `FOLLOWER_LAYOUT_PANELS` and `rebuildFollowerLayout` still expose only Single / Top-Bottom / Left-Right / Quad. Easy follow-up if desired.
- Custom SVG glyphs for the new picker icons (currently ⊤ / ⊥).

## Test plan

- [x] Load a song with ≥3 arrangements.
- [x] Hit Split, cycle the layout picker through all 5 layouts.
- [x] Confirm `tri-top`: top spans full width; bottom row has 2 equal panels.
- [x] Confirm `tri-bottom`: top row has 2 equal panels; bottom spans full width.
- [x] Confirm P1 = lead, P2 = rhythm, P3 = bass on a fresh load (no saved prefs).
- [x] Switch back and forth between `quad ↔ tri-top ↔ tri-bottom ↔ top-bottom` and verify no orphan panels or canvas-sizing bugs.
- [x] Reload page after picking a tri layout — confirm `localStorage.splitscreenLayout` persists.
- [x] Settings → confirm both new options are present in the default-layout dropdown.
- [x] Open a viz-mode panel (e.g. 3D Highway) in tri layout to confirm WebGL canvas swapping still works in 3-panel mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)